### PR TITLE
GitHub Actions の ver. を tag ではなく commit hash で指定する

### DIFF
--- a/.github/workflows/on-pull_request.yml
+++ b/.github/workflows/on-pull_request.yml
@@ -16,7 +16,7 @@ jobs:
       # https://docs.github.com/ja/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
       # https://docs.github.com/ja/webhooks/webhook-events-and-payloads?actionType=reopened#pull_request
       # https://docs.github.com/ja/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             console.info("github.event", context.payload)

--- a/.github/workflows/on-workflow_run-completed.yml
+++ b/.github/workflows/on-workflow_run-completed.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://docs.github.com/ja/webhooks/webhook-events-and-payloads?actionType=completed#workflow_run
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             console.info("github.event", context.payload)

--- a/.github/workflows/wf-lint-gha.yml
+++ b/.github/workflows/wf-lint-gha.yml
@@ -9,12 +9,12 @@ jobs:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-yamllint@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0
         with:
           fail_level: error
           reporter: github-pr-review
-      - uses: reviewdog/action-actionlint@v1
+      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281
         with:
           # fail_level: error
           fail_on_error: true

--- a/.github/workflows/wf-observe-gha.yml
+++ b/.github/workflows/wf-observe-gha.yml
@@ -15,7 +15,7 @@ jobs:
           echo -n "${{github.event.workflow_run.path}}" | \
           node -e 'console.info("filename=" + /([^/]+)\.ya?ml$/.exec(require("fs").readFileSync(0, "utf-8"))[1])' >> "$GITHUB_OUTPUT"
         # yamllint enable rule:line-length
-      - uses: corentinmusard/otel-cicd-action@v2
+      - uses: corentinmusard/otel-cicd-action@32b29919dceea928e1c83dc69804973061a68825
         with:
           githubToken: ${{secrets.GITHUB_TOKEN}}
           otelServiceName: ${{steps.get-the-workflow-filename.outputs.filename}}


### PR DESCRIPTION
cf. https://github.com/tj-actions/changed-files/security/advisories/GHSA-mw4p-6x4p-x5m5

Renovate が更新してくれるかも確かめる