### PR TITLE
Only required secrets should be passed explicitly

### DIFF
--- a/.github/workflows/on-pull_request-workflow_run-completed.yaml
+++ b/.github/workflows/on-pull_request-workflow_run-completed.yaml
@@ -27,4 +27,6 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/wf-observe-gha.yaml
-    secrets: inherit
+    secrets:
+      MACKEREL_APIKEY: ${{ secrets.MACKEREL_APIKEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull_request-workflow_run-completed.yaml
+++ b/.github/workflows/on-pull_request-workflow_run-completed.yaml
@@ -29,4 +29,4 @@ jobs:
     uses: ./.github/workflows/wf-observe-gha.yaml
     secrets:
       MACKEREL_APIKEY: ${{ secrets.MACKEREL_APIKEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      secrets_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull_request.yaml
+++ b/.github/workflows/on-pull_request.yaml
@@ -24,4 +24,4 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/wf-lint-gha.yaml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      secrets_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pull_request.yaml
+++ b/.github/workflows/on-pull_request.yaml
@@ -23,4 +23,5 @@ jobs:
       contents: read
       pull-requests: write
     uses: ./.github/workflows/wf-lint-gha.yaml
-    secrets: inherit
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wf-lint-gha.yaml
+++ b/.github/workflows/wf-lint-gha.yaml
@@ -3,6 +3,9 @@ name: Lint GitHub Actions
 
 "on":
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   lint-gha:
@@ -19,9 +22,11 @@ jobs:
       - uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0  # v1.21.0
         with:
           fail_level: error
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
       - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281  # v1.65.2
         with:
           # fail_level: error
           fail_on_error: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/wf-lint-gha.yaml
+++ b/.github/workflows/wf-lint-gha.yaml
@@ -4,7 +4,7 @@ name: Lint GitHub Actions
 "on":
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
+      secrets_github_token:
         required: true
 
 jobs:
@@ -22,11 +22,11 @@ jobs:
       - uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0  # v1.21.0
         with:
           fail_level: error
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.secrets_github_token }}
           reporter: github-pr-review
       - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281  # v1.65.2
         with:
           # fail_level: error
           fail_on_error: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.secrets_github_token }}
           reporter: github-pr-review

--- a/.github/workflows/wf-observe-gha.yaml
+++ b/.github/workflows/wf-observe-gha.yaml
@@ -4,7 +4,7 @@ name: Observe GitHub Actions
 "on":
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
+      secrets_github_token:
         required: true
       MACKEREL_APIKEY:
         required: true
@@ -30,7 +30,7 @@ jobs:
             core.setOutput("filename", match[1]);
       - uses: corentinmusard/otel-cicd-action@32b29919dceea928e1c83dc69804973061a68825  # v2.2.3
         with:
-          githubToken: ${{secrets.GITHUB_TOKEN}}
+          githubToken: ${{secrets.secrets_github_token}}
           otelServiceName: ${{steps.get-the-workflow-filename.outputs.filename}}
           otlpEndpoint: https://otlp-vaxila.mackerelio.com/v1/traces
           otlpHeaders: Accept=*/*,Mackerel-Api-Key=${{secrets.MACKEREL_APIKEY}}

--- a/.github/workflows/wf-observe-gha.yaml
+++ b/.github/workflows/wf-observe-gha.yaml
@@ -3,6 +3,11 @@ name: Observe GitHub Actions
 
 "on":
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      MACKEREL_APIKEY:
+        required: true
 
 jobs:
   otel-cicd-action:

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ help:
 lint-gha: ## Lint GitHub Actions
 	yamllint .github/workflows/
 	actionlint
-	ghalint run || true
-	zizmor . || true
+	ghalint run
+	zizmor .


### PR DESCRIPTION
```
ERRO[0000] the job violates policies                     error="`secrets: inherit` should not be used. Only required secrets should be passed explicitly" job_name=observe-gha policy_name=deny_inherit_secrets program=ghalint reference="https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/004.md" version=1.3.0 workflow_file_path=云々
```

```
warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/on-pull_request-workflow_run-completed.yaml:29:5
   |
29 |     uses: ./.github/workflows/wf-observe-gha.yaml
   |     --------------------------------------------- this reusable workflow
30 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High
```