### PR TITLE
手元でrenovateのmigrationを檢出する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,4 @@ lint-gha:
 	zizmor .
 
 lint-renovate:
-	npx --package renovate -- renovate-config-validator
+	npx --package renovate -- renovate-config-validator --strict


### PR DESCRIPTION
Config Validation - Renovate Docs#Strict mode¶ https://docs.renovatebot.com/config-validation/#strict-mode
> You can pass the --strict flag to make it fail if a scanned config needs migration

Renovateがmigrationするpull requestを作ってくれる (例: https://github.com/ne-sachirou/otelcol-config/pull/46 ) から、Actionsではstrictで檢査しない。