### PR TITLE
Revert "Update dependency aquaproj/aqua to v2.53.9"

### DIFF
--- a/.github/workflows/wf-lint-gha.yaml
+++ b/.github/workflows/wf-lint-gha.yaml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f  # v4.0.2
         with:
-          aqua_version: v2.53.9
+          aqua_version: v2.53.8
       - run: |
           ghalint run
         env:
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f  # v4.0.2
         with:
-          aqua_version: v2.53.9
+          aqua_version: v2.53.8
       - run: |
           zizmor .
         env:


### PR DESCRIPTION
Reverts ne-sachirou/github-actions-playground#117

https://github.com/ne-sachirou/github-actions-playground/actions/runs/16824485993
> time=2025-08-08T07:19:58Z level=error msg=ignore a package because the package version is empty env=linux/amd64 error=install the package package_name=takumin/zizmor-bin package_version=v1.8.0 program=aqua program_version=2.53.9 registry=standard
time=2025-08-08T07:19:58Z level=info msg=create a symbolic link command=ghalint env=linux/amd64 package_name=suzuki-shunsuke/ghalint package_version=v1.5.3 program=aqua program_version=2.53.9
time=2025-08-08T07:19:58Z level=fatal msg=aqua failed config_file_path=/home/runner/work/github-actions-playground/github-actions-playground/aqua.yaml env=linux/amd64 error=install packages: it failed to install some packages program=aqua program_version=2.53.9

zizmor-bin は https://github.com/aquaproj/aqua-registry/tree/fcd490319cb65478668b9753c4f4429fc9705939/pkgs/takumin/zizmor-bin に在るが…。

https://github.com/aquaproj/aqua/blob/8982da80a3c653e060b8c48881216c9a2ea1018c/pkg/config/extract.go#L78-L89 から log は吐かれてある。