### PR TITLE
Please update your workflows to use dash0hq/otel-cicd-action@v4 instead of corentinmusard/otel-cicd-action@v4.

### DIFF
--- a/.github/workflows/wf-observe-gha.yaml
+++ b/.github/workflows/wf-observe-gha.yaml
@@ -28,7 +28,7 @@ jobs:
             const match = path.match(/([^/]+)\.ya?ml$/);
             if (!match) throw new Error("Invalid workflow filename");
             core.setOutput("filename", match[1]);
-      - uses: corentinmusard/otel-cicd-action@f2d88ecf54d9dd3e01ea95e25f93603212ee93d3 # v4.0.1
+      - uses: dash0hq/otel-cicd-action@f2d88ecf54d9dd3e01ea95e25f93603212ee93d3 # v4.0.1
         with:
           githubToken: ${{github.token}}
           otelServiceName: ${{steps.get-the-workflow-filename.outputs.filename}}


### PR DESCRIPTION
[📢 Repository transferred to dash0hq — action continues under new ownership · dash0hq/otel-cicd-action · Discussion #72](https://github.com/dash0hq/otel-cicd-action/discussions/72)